### PR TITLE
angular.json: increase build budget

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -47,8 +47,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1.5MB",
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
Maximum build size was 1 MB, but we have 1.59 MB.
For now I suggest to increase the maximum build size to 2 MB so we can proceed with the development. We can discuss if we want the initial chunks to be smaller and how to achieve that.